### PR TITLE
Allow zone network to be configured in plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -257,6 +257,23 @@ vagrant zones config key value
 vagrant zones config --delete key
 ```
 
+### Network
+
+Networks conflict, particularly when assumptions are made about local
+networks. For this reason, the network chosen by the plugin when
+configuring the Global Zone and its local zone can be globally
+overridden.
+
+```bash
+vagrant zones config network 10.0.0.0/24
+```
+
+What can go wrong? Well... basically, what can go wrong is that the
+Global Zone port forwarding will break, and we won't actually be able to
+create zones. It should be pretty obvious when this is the case.
+
+* Does your network overlap with VirtualBox's local network space?
+
 ### Pkgsrc mirror
 
 ```bash

--- a/files/gz_vnic/create_gz_vnic
+++ b/files/gz_vnic/create_gz_vnic
@@ -3,13 +3,13 @@
 dladm create-etherstub stub0
 dladm create-vnic -l stub0 vnic0
 ipadm create-if vnic0
-ipadm create-addr -T static -a 172.16.0.1/24 vnic0/static
+ipadm create-addr -T static -a <gz_addr> vnic0/static
 
-echo 'map e1000g0 172.16.0.0/24 -> 0.0.0.0/32' | ipnat -f -
+echo 'map e1000g0 <zone_network> -> 0.0.0.0/32' | ipnat -f -
 
 # When we SSH into port 2222, ensure that that goes to 22 in the GZ
 # and is never forwarded to the zone.
-echo 'rdr e1000g0 0.0.0.0/0 port 2222 -> 172.16.0.1 port 22' | ipnat -f -
+echo 'rdr e1000g0 0.0.0.0/0 port 2222 -> <gz_ip> port 22' | ipnat -f -
 
 routeadm -u -e ipv4-forwarding
 routeadm -u -e ipv4-routing

--- a/lib/vagrant/smartos/zones/cap/create_gz_vnic.rb
+++ b/lib/vagrant/smartos/zones/cap/create_gz_vnic.rb
@@ -1,4 +1,5 @@
 require 'vagrant/smartos/zones/cap/base'
+require 'vagrant/smartos/zones/models/network'
 
 module Vagrant
   module Smartos
@@ -13,10 +14,13 @@ module Vagrant
             ui.info 'Installing vnic in global zone'
             sudo = machine.config.smartos.suexec_cmd
 
-            machine.communicate.upload(create_vnic_script, '%s/create_gz_vnic' % vm_tmp_folder)
+            machine.communicate.upload(create_vnic_script, tmp_script)
+            machine.communicate.execute('sed -i -e \'s@<gz_addr>@%s@\' %s' % [network.gz_addr, tmp_script])
+            machine.communicate.execute('sed -i -e \'s@<zone_network>@%s@\' %s' % [network.zone_network, tmp_script])
+            machine.communicate.execute('sed -i -e \'s@<gz_ip>@%s@\' %s' % [network.gz_stub_ip, tmp_script])
             machine.communicate.upload(vnic_smf_manifest, '%s/create-gz-vnic.xml' % vm_tmp_folder)
 
-            machine.communicate.execute("#{sudo} mv %s/create_gz_vnic /opt/custom/method" % vm_tmp_folder)
+            machine.communicate.execute("#{sudo} mv %s /opt/custom/method" % tmp_script)
             machine.communicate.execute("#{sudo} mv %s/create-gz-vnic.xml /opt/custom/smf" % vm_tmp_folder)
 
             machine.communicate.execute("#{sudo} svccfg import /opt/custom/smf/create-gz-vnic.xml")
@@ -29,6 +33,14 @@ module Vagrant
 
           def create_vnic_script
             File.join(local_files_folder, 'gz_vnic', 'create_gz_vnic')
+          end
+
+          def network
+            @network ||= Models::Network.new(machine.env)
+          end
+
+          def tmp_script
+            '%s/create_gz_vnic' % vm_tmp_folder
           end
 
           def vnic_smf_manifest

--- a/lib/vagrant/smartos/zones/models/network.rb
+++ b/lib/vagrant/smartos/zones/models/network.rb
@@ -1,0 +1,48 @@
+require 'netaddr'
+require 'vagrant/smartos/zones/models/config'
+
+module Vagrant
+  module Smartos
+    module Zones
+      module Models
+        class Network
+          attr_reader :env
+
+          def initialize(env)
+            @env = env
+          end
+
+          def network
+            plugin_config.hash['network'] || '172.16.0.0/24'
+          end
+
+          def zone_network
+            [cidr.network, cidr.bits].join('/')
+          end
+
+          def gz_addr
+            [gz_stub_ip, cidr.bits].join('/')
+          end
+
+          def gz_stub_ip
+            cidr[1].ip
+          end
+
+          def zone_ip
+            cidr[2].ip
+          end
+
+          private
+
+          def cidr
+            @cidr ||= NetAddr::CIDR.create(network)
+          end
+
+          def plugin_config
+            @config ||= Models::Config.config(env)
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/vagrant/smartos/zones/util/zone_json.rb
+++ b/lib/vagrant/smartos/zones/util/zone_json.rb
@@ -1,3 +1,5 @@
+require 'vagrant/smartos/zones/models/network'
+
 module Vagrant
   module Smartos
     module Zones
@@ -51,7 +53,7 @@ module Vagrant
 
           def nics
             {
-              'nics' => [nic_info('stub0', '172.16.0.2')]
+              'nics' => [nic_info('stub0', network.zone_ip)]
             }
           end
 
@@ -60,7 +62,7 @@ module Vagrant
               'nic_tag' => tag,
               'ip' => ip,
               'netmask' => '255.255.255.0',
-              'gateway' => '172.16.0.1',
+              'gateway' => network.gz_stub_ip,
               'allow_ip_spoofing' => true
             }
           end
@@ -69,6 +71,10 @@ module Vagrant
 
           def lx_brand?
             machine.config.zone.brand == 'lx'
+          end
+
+          def network
+            @network ||= Models::Network.new(machine.env)
           end
         end
       end

--- a/vagrant-smartos-zones.gemspec
+++ b/vagrant-smartos-zones.gemspec
@@ -18,6 +18,8 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(/^(test|spec|features)\//)
   spec.require_paths = ['lib']
 
+  spec.add_dependency 'netaddr'
+
   spec.add_development_dependency 'bundler', '~> 1.5'
   spec.add_development_dependency 'pry-nav'
   spec.add_development_dependency 'rake'


### PR DESCRIPTION
  vagrant zones config network 10.0.0.1/24

Does not do any checks to ensure that configuration is valid
or that it does not conflict with virtualization software's
private network assigned to the VM's primary IP.