### PR TITLE
Fixed typographical error, changed arbitary to arbitrary in README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -327,7 +327,7 @@ Any success of this project depends heavily on the work of others,
 which I've either learned from or pulled in directly.
 
 * https://github.com/joshado/vagrant-smartos - Vagrant plugin for
-  managing zones on a global zone running on an arbitary IP.
+  managing zones on a global zone running on an arbitrary IP.
 * https://github.com/groundwater/vagrant-smartos - Scripts for 
   creating stand-alone boxes where GZ networking is twerked to pretend
   that the local zone is the only thing in the box.


### PR DESCRIPTION
@vagrant-smartos, I've corrected a typographical error in the documentation of the [vagrant-smartos-zones](https://github.com/vagrant-smartos/vagrant-smartos-zones) project. You should be able to merge this pull request automatically. However, if this was intentional or if you enjoy living in linguistic squalor, please let me know and [create an issue](https://github.com/thoppe/orthographic-pedant/issues/new) on my home repository.