### PR TITLE
Fix issue with undefined local variable or method `ui'

### DIFF
--- a/lib/vagrant/smartos/zones/commands/multi_command.rb
+++ b/lib/vagrant/smartos/zones/commands/multi_command.rb
@@ -29,7 +29,7 @@ module Vagrant
             command_method = subcommands.find { |c| c == command }
 
             unless command_method
-              ui.warn option_parser.to_s, prefix: false
+              @env.ui.warn option_parser.to_s, prefix: false
               exit 1
             end
 
@@ -38,7 +38,7 @@ module Vagrant
           end
 
           def fail_options!
-            ui.warn option_parser.to_s, prefix: false
+            @env.ui.warn option_parser.to_s, prefix: false
             exit 1
           end
 


### PR DESCRIPTION
The `vagrant global-zone` command failed with the newest vagrant version:

```
/Users/tm/.vagrant.d/gems/gems/vagrant-smartos-zones-0.2.2/lib/vagrant/smartos/zones/commands/multi_command.rb:32:in `process_subcommand': undefined local variable or method `ui' for #<Vagrant::Smartos::Zones::Command::GlobalZone:0x000001021f7c98> (NameError)
	from /Users/tm/.vagrant.d/gems/gems/vagrant-smartos-zones-0.2.2/lib/vagrant/smartos/zones/commands/multi_command.rb:17:in `execute'
	from /opt/vagrant/embedded/gems/gems/vagrant-1.8.4/lib/vagrant/cli.rb:42:in `execute'
	from /opt/vagrant/embedded/gems/gems/vagrant-1.8.4/lib/vagrant/environment.rb:302:in `cli'
	from /opt/vagrant/embedded/gems/gems/vagrant-1.8.4/bin/vagrant:174:in `<main>'
```