### PR TITLE
A new version of netaddr has been released, this version is no longer…

### DIFF
--- a/lib/vagrant/smartos/zones/version.rb
+++ b/lib/vagrant/smartos/zones/version.rb
@@ -1,7 +1,7 @@
 module Vagrant
   module Smartos
     module Zones
-      VERSION = '0.2.3'
+      VERSION = '0.2.4'
     end
   end
 end

--- a/vagrant-smartos-zones.gemspec
+++ b/vagrant-smartos-zones.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(/^(test|spec|features)\//)
   spec.require_paths = ['lib']
 
-  spec.add_dependency 'netaddr'
+  spec.add_dependency 'netaddr', '~> 1.5.1'
 
   spec.add_development_dependency 'bundler', '~> 1.5'
   spec.add_development_dependency 'pry-nav'


### PR DESCRIPTION
… compatible with the used version 1.5.x

spec.add_dependency should depend on the version of netaddr which is supported by the code. For that reason ~> 1.5.1 is required.